### PR TITLE
Add setup_all block to game state test module

### DIFF
--- a/test/socketfight/game_state_test.exs
+++ b/test/socketfight/game_state_test.exs
@@ -1,4 +1,4 @@
-defmodule AssertionTest do
+defmodule Socketfight.GameStateTest do
   use ExUnit.Case, async: true
   alias Socketfight.CollisionDetector
 
@@ -22,7 +22,10 @@ defmodule AssertionTest do
     assert CollisionDetector.point_inside_box(1, 1, 0, 2, 2, 0)
   end
 
-  test "no collision" do
+  # setup_all gets run once before any tests run, allowing us to
+  # prepare a state for every test in one go. It is expected to
+  # return an {:ok, state} tuple.
+  setup_all do
     player = %{
       id: 0,
       radius: 40,
@@ -34,9 +37,13 @@ defmodule AssertionTest do
       }
     }
 
-    obstacle = %{a: %{x: 0, y: 200}, b: %{x: 200, y: 200}}
+    state = %{player: player}
+    {:ok, state}
+  end
 
-    assert !CollisionDetector.collides?(player, obstacle)
+  test "no collision", state do
+    obstacle = %{a: %{x: 0, y: 200}, b: %{x: 200, y: 200}}
+    assert !CollisionDetector.collides?(state.player, obstacle)
   end
 
   test "collision" do
@@ -56,38 +63,14 @@ defmodule AssertionTest do
     assert CollisionDetector.collides?(player, obstacle)
   end
 
-  test "touch" do
-    player = %{
-      id: 0,
-      radius: 40,
-      state: %{
-        x: 100,
-        y: 100,
-        newX: 100,
-        newY: 100
-      }
-    }
-
+  test "touch", state do
     obstacle = %{a: %{x: 0, y: 120}, b: %{x: 200, y: 120}}
-
-    assert CollisionDetector.collides?(player, obstacle)
+    assert CollisionDetector.collides?(state.player, obstacle)
   end
 
-  test "inside" do
-    player = %{
-      id: 0,
-      radius: 40,
-      state: %{
-        x: 100,
-        y: 100,
-        newX: 100,
-        newY: 100
-      }
-    }
-
+  test "inside", state do
     obstacle = %{a: %{x: 0, y: 100}, b: %{x: 90, y: 100}}
-
-    assert CollisionDetector.collides?(player, obstacle)
+    assert CollisionDetector.collides?(state.player, obstacle)
   end
 
   # TODO: If the line is very small and completely inside the circle that's
@@ -109,21 +92,9 @@ defmodule AssertionTest do
   #   assert CollisionDetector.collides?(player, obstacle)
   # end
 
-  test "outside but in the same line" do
-    player = %{
-      id: 0,
-      radius: 40,
-      state: %{
-        x: 100,
-        y: 100,
-        newX: 100,
-        newY: 100
-      }
-    }
-
+  test "outside but in the same line", state do
     obstacle = %{a: %{x: 200, y: 100}, b: %{x: 600, y: 100}}
-
-    assert !CollisionDetector.collides?(player, obstacle)
+    assert !CollisionDetector.collides?(state.player, obstacle)
   end
 
   test "outside but in the same line 2" do


### PR DESCRIPTION
Adding a `setup_all` block makes it easier to share a common state for multiple tests, removing the need to duplicate it from test to test.