### PR TITLE
Move Player-related functions to a new Player module

### DIFF
--- a/lib/socketfight/game_state.ex
+++ b/lib/socketfight/game_state.ex
@@ -4,6 +4,7 @@
 defmodule Socketfight.GameState do
   use Agent
   alias Socketfight.CollisionDetector
+  alias Socketfight.Player
 
   # @arena_width 1080
   # @arena_height 720
@@ -73,7 +74,7 @@ defmodule Socketfight.GameState do
       player ->
         player
         |> update_player_meta(action, state)
-        |> update_player
+        |> update_player()
     end
   end
 
@@ -88,20 +89,13 @@ defmodule Socketfight.GameState do
   def tick() do
     Enum.each(players(), fn {_key, player} ->
       # Setup shoot cooldown
-      player =
-        cond do
-          player.state.shootCooldown > 0 ->
-            update_in(player, [:state, :shootCooldown], fn shootCooldown -> shootCooldown - 1 end)
-
-          true ->
-            player
-        end
+      player = Player.handle_shoot_cooldown(player)
 
       # Reset collision state.
-      updated_player = update_in(player, [:state, :collision], fn _ -> false end)
+      updated_player = Player.reset_collision(player)
 
       # Reset shot state.
-      updated_player = update_in(updated_player, [:state, :shot], fn _ -> false end)
+      updated_player = Player.reset_shot_state(updated_player)
 
       # Filter out names of active actions.
       taken_actions =
@@ -112,15 +106,21 @@ defmodule Socketfight.GameState do
       # Run action handlers.
       updated_player =
         taken_actions
-        |> Enum.reduce(updated_player, fn action, player -> handle_player(player, action) end)
+        |> Enum.reduce(updated_player, fn action, player ->
+          Player.handle_action(player, action)
+        end)
 
       # Handle damage dealt by shooting.
-      deal_damage(updated_player, players(), updated_player.state.shot)
+        damaged_players = Player.deal_damage(updated_player, players(), updated_player.state.shot)
+
+        if is_list(damaged_players) do
+          Enum.each(damaged_players, fn(x) -> update_player(x) end)
+        end
 
       # Clean players with less than zero health.
       players()
       |> Enum.filter(fn {_, player} -> player.state.health <= 0 end)
-      |> Enum.map(fn {_, player} -> handle_death(player) end)
+      |> Enum.map(fn {_, player} -> Player.handle_action(player, "death") |> update_player() end)
 
       # Run collision detection. If no collisions, move player. Otherwise cancel move.
       if !Enum.any?(obstacles(), fn obstacle ->
@@ -145,108 +145,11 @@ defmodule Socketfight.GameState do
           update_in(updated_player, [:state, :y], fn _ -> updated_player.state.newY end)
 
         # Update player.
-        updated_player |> update_player
+        updated_player |> update_player()
       else
         # Update player.
-        updated_player |> update_player
+        updated_player |> update_player()
       end
     end)
-  end
-
-  @doc """
-  Check if player has shot and deal damage to players hit by bullet. Returns
-  a player with updated kills status.
-  """
-  def deal_damage(player, players, true) do
-    # Loop through each opponent. Check collisions.
-    players_hit =
-      players
-      |> Enum.filter(fn {_, target_player} ->
-        elem(
-          CollisionDetector.collides?(
-            target_player.state.x,
-            target_player.state.y,
-            target_player.radius,
-            player.state.x,
-            player.state.y,
-            player.state.shootTargetX,
-            player.state.shootTargetY
-          ),
-          0
-        )
-      end)
-
-    # Order list based on distance.
-
-    # Loop through hit players
-    players_hit
-    |> Enum.map(fn {_, target_player} ->
-      # Reduce target player health.
-      update_in(target_player, [:state, :health], fn health -> health - 20 end)
-      |> update_player
-    end)
-  end
-
-  @doc """
-  In case weapon is not shot, no damage is done.
-  """
-  def deal_damage(player, _, _) do
-    player
-  end
-
-  @doc """
-  If player dies, increase death counter and reset location.
-  """
-  def handle_death(player) do
-    player
-    |> update_in([:state, :health], fn _ -> 100 end)
-    |> update_in([:state, :deaths], fn deaths -> deaths + 1 end)
-    |> update_player
-  end
-
-  # def handle_bullet_damage(player, players) do
-  # end
-
-  def handle_player(player, "forward") do
-    xOffset = :math.cos(player.state.rotation + :math.pi() / 2) * 5
-    yOffset = :math.sin(player.state.rotation + :math.pi() / 2) * 5
-    player = update_in(player, [:state, :newX], fn _ -> player.state.x - xOffset end)
-    update_in(player, [:state, :newY], fn _ -> player.state.y - yOffset end)
-  end
-
-  def handle_player(player, "brake") do
-    xOffset = :math.cos(player.state.rotation + :math.pi() / 2) * 5
-    yOffset = :math.sin(player.state.rotation + :math.pi() / 2) * 5
-    player = update_in(player, [:state, :newX], fn x -> x + xOffset end)
-    update_in(player, [:state, :newY], fn y -> y + yOffset end)
-  end
-
-  def handle_player(player, "left") do
-    update_in(player, [:state, :rotation], fn rotation -> rotation - :math.pi() / 60 end)
-  end
-
-  def handle_player(player, "right") do
-    update_in(player, [:state, :rotation], fn rotation -> rotation + :math.pi() / 60 end)
-  end
-
-  @doc """
-  Shoot weapon.
-  """
-  def handle_player(player, "shoot") do
-    # If cooldown is over and shoot-button is enabled.
-    if player.state.shootCooldown == 0 && player.actions["shoot"] == true do
-      # Calculate end point.
-      xOffset = :math.cos(player.state.rotation + :math.pi() / 2) * 400
-      yOffset = :math.sin(player.state.rotation + :math.pi() / 2) * 400
-      IO.puts("Shoot to: #{xOffset} #{yOffset}")
-
-      # Update states.
-      player = update_in(player, [:state, :shootTargetX], fn _ -> player.state.x - xOffset end)
-      player = update_in(player, [:state, :shootTargetY], fn _ -> player.state.y - yOffset end)
-      player = update_in(player, [:state, :shot], fn _ -> true end)
-      update_in(player, [:state, :shootCooldown], fn _ -> 30 end)
-    else
-      player
-    end
   end
 end

--- a/lib/socketfight/player.ex
+++ b/lib/socketfight/player.ex
@@ -1,0 +1,180 @@
+defmodule Socketfight.Player do
+  alias Socketfight.CollisionDetector
+
+  @moduledoc """
+  This module contains functions to interact with representations of players.
+  The functions in this module are meant to transform player-related data,
+  but they should not know anything about how the game is actually run.
+  """
+
+  @doc """
+  Create a new data representation of a player. `player_id` is expected
+  to be an unique string identifier for the player.
+  """
+  @spec new(String.t()) :: map()
+  def new(player_id) when is_binary(player_id) do
+    %{
+      id: player_id,
+      radius: 20,
+      actions: %{
+        forward: false,
+        left: false,
+        right: false,
+        brake: false,
+        shoot: false
+      },
+      state: %{
+        x: 540,
+        y: 360,
+        newX: 540,
+        newY: 360,
+        collision: false,
+        rotation: 0.0,
+        shootCooldown: 0,
+        shootTargetX: 0,
+        shootTargetY: 0,
+        shot: false,
+        health: 100,
+        kills: 0,
+        deaths: 0
+      }
+    }
+  end
+
+  def new(_player_id), do: {:error, "player_id not a string"}
+
+  @doc """
+  If player dies, increase death counter and reset health.
+  """
+  def handle_action(player, "death") do
+    player
+    |> update_in([:state, :health], fn _ -> 100 end)
+    |> update_in([:state, :deaths], fn deaths -> deaths + 1 end)
+  end
+
+  @doc """
+  Handle player moving forward.
+  """
+  def handle_action(player, "forward") do
+    xOffset = :math.cos(player.state.rotation + :math.pi() / 2) * 5
+    yOffset = :math.sin(player.state.rotation + :math.pi() / 2) * 5
+    player = update_in(player, [:state, :newX], fn _ -> player.state.x - xOffset end)
+    update_in(player, [:state, :newY], fn _ -> player.state.y - yOffset end)
+  end
+
+  @doc """
+  Handle player moving backwards.
+  """
+  def handle_action(player, "brake") do
+    xOffset = :math.cos(player.state.rotation + :math.pi() / 2) * 5
+    yOffset = :math.sin(player.state.rotation + :math.pi() / 2) * 5
+    player = update_in(player, [:state, :newX], fn x -> x + xOffset end)
+    update_in(player, [:state, :newY], fn y -> y + yOffset end)
+  end
+
+  @doc """
+  Handle player moving left.
+  """
+  def handle_action(player, "left") do
+    update_in(player, [:state, :rotation], fn rotation -> rotation - :math.pi() / 60 end)
+  end
+
+  @doc """
+  Handle player moving right.
+  """
+  def handle_action(player, "right") do
+    update_in(player, [:state, :rotation], fn rotation -> rotation + :math.pi() / 60 end)
+  end
+
+  @doc """
+  Handle player shooting.
+  """
+  def handle_action(player, "shoot") do
+    # If cooldown is over and shoot-button is enabled.
+    if player.state.shootCooldown == 0 && player.actions["shoot"] == true do
+      # Calculate end point.
+      xOffset = :math.cos(player.state.rotation + :math.pi() / 2) * 400
+      yOffset = :math.sin(player.state.rotation + :math.pi() / 2) * 400
+      IO.puts("Shoot to: #{xOffset} #{yOffset}")
+
+      # Update states.
+      player = update_in(player, [:state, :shootTargetX], fn _ -> player.state.x - xOffset end)
+      player = update_in(player, [:state, :shootTargetY], fn _ -> player.state.y - yOffset end)
+      player = update_in(player, [:state, :shot], fn _ -> true end)
+      update_in(player, [:state, :shootCooldown], fn _ -> 30 end)
+    else
+      player
+    end
+  end
+
+  @doc """
+  Handle shoot cooldown for a player.
+  """
+  def handle_shoot_cooldown(player) do
+    cond do
+      player.state.shootCooldown > 0 ->
+        update_in(player, [:state, :shootCooldown], fn shootCooldown -> shootCooldown - 1 end)
+
+      true ->
+        player
+    end
+  end
+
+  @doc """
+  Reset player collision state.
+  """
+  def reset_collision(player) do
+    update_in(player, [:state, :collision], fn _ -> false end)
+  end
+
+  @doc """
+  Reset player shot state.
+  """
+  def reset_shot_state(player) do
+    update_in(player, [:state, :shot], fn _ -> false end)
+  end
+
+  @doc """
+  Check if player has shot and deal damage to players hit by bullet. Returns
+  a player with updated kills status.
+  """
+  @spec deal_damage(map(), list(), boolean()) :: list()
+  def deal_damage(player, players, true) do
+    # Loop through each opponent. Check collisions.
+    players_hit =
+      players
+      |> Enum.filter(fn {_, target_player} ->
+        elem(
+          CollisionDetector.collides?(
+            target_player.state.x,
+            target_player.state.y,
+            target_player.radius,
+            player.state.x,
+            player.state.y,
+            player.state.shootTargetX,
+            player.state.shootTargetY
+          ),
+          0
+        )
+      end)
+
+    # Order list based on distance.
+
+    # Loop through hit players
+    players_hit
+    |> Enum.map(fn {_, target_player} ->
+      # Reduce target player health.
+      update_in(target_player, [:state, :health], fn health -> health - 20 end)
+    end)
+  end
+
+  @doc """
+  In case weapon is not shot, no damage is done.
+  """
+  def deal_damage(player, _, _) do
+    player
+  end
+
+  # def handle_bullet_damage(player, players) do
+  # end
+end

--- a/lib/socketfight_web/channels/game_channel.ex
+++ b/lib/socketfight_web/channels/game_channel.ex
@@ -3,10 +3,11 @@
 defmodule SocketfightWeb.GameChannel do
   use Phoenix.Channel
   alias Socketfight.GameState
+  alias Socketfight.Player
 
   def join("game:default", message, socket) do
     # Notify self.
-    send(self, {:after_join, message})
+    send(self(), {:after_join, message})
     {:ok, socket}
   end
 
@@ -26,45 +27,17 @@ defmodule SocketfightWeb.GameChannel do
   end
 
   def handle_in("join", %{}, socket) do
-    player_id = socket.assigns.player_id
-
-    # Create new player
-    player = %{
-      id: player_id,
-      radius: 20,
-      actions: %{
-        forward: false,
-        left: false,
-        right: false,
-        brake: false,
-        shoot: false
-      },
-      state: %{
-        x: 540,
-        y: 360,
-        newX: 540,
-        newY: 360,
-        collision: false,
-        rotation: 0.0,
-        shootCooldown: 0,
-        shootTargetX: 0,
-        shootTargetY: 0,
-        shot: false,
-        health: 100,
-        kills: 0,
-        deaths: 0
-      }
-    }
-
-    # Add player to the game.
-    player = GameState.put_player(player)
+    # Create new player and add it to the game
+    socket.assigns.player_id
+    |> Player.new()
+    |> GameState.put_player()
 
     {:noreply, socket}
   end
 
   def handle_in("event", %{"action" => action, "state" => state}, socket) do
     player_id = socket.assigns.player_id
-    player = GameState.update_player_action(player_id, action, state)
+    GameState.update_player_action(player_id, action, state)
     {:noreply, socket}
   end
 end


### PR DESCRIPTION
The primary goal of this PR is to clarify the separation of concerns for the game by moving all player-related functions to a new Player module. The primary benefit of this is that the GameState module now only needs to deal with the _state_ of the game, freeing it from caring _how_ the player actions themselves are performed.

I believe this makes sense because everything that happens in the new Player module is data transformation. The Player should not need to be coupled with the state of a game, and the state of the game should not need to know the details of how a Player reaches a new form; all it should care about is that the internal state is managed correctly.

This PR does NOT address https://github.com/jaamo/socketfight/issues/13 because I realized that fixing that issue would require quite a bit of refactoring (as Structs are internally "bare maps", which means Kernel operations such as get_in or update_in would not work as-is). I did still move the representation of a default Player map away from the Game Channel, as the new Player module felt like the right place for it now.